### PR TITLE
Add googletest ut framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ This is similar to the requirements of most MPI implementations and a
 generally tested path in Libfabric.  For GPUDirect RDMA support, the
 plugin also requires `FI_HMEM` support, as well as RDMA support.
 
+## Unit Testing
+
+The project includes a GoogleTest/GoogleMock framework for unit testing with
+complete libfabric API mocking.  To build and run unit tests:
+
+```bash
+./configure --enable-gtest
+make check
+```
+
+See [tests/unit/GTEST_README.md](tests/unit/GTEST_README.md) for details on
+writing tests and adding new mocks.
+
 ## Getting Help
 
 If you have any issues in building or using the package or if you think you may

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,10 @@ AS_IF([test "${enable_tests}" != "no" -a "${found_mpi}" = "no" ],
 AS_IF([test "${enable_tests}" != "no" -a "${have_device_interface}" = "neuron" ],
       [AC_MSG_WARN([Functional tests not available on neuron, disabling.])
        build_func_tests=no])
+
+# Check for GoogleTest/GoogleMock
+CHECK_PKG_GTEST()
+
 AM_CONDITIONAL([ENABLE_UNIT_TESTS], [test "$build_unit_tests" == "yes"])
 AM_CONDITIONAL([ENABLE_FUNC_TESTS], [test "$build_func_tests" == "yes"])
 
@@ -350,4 +354,5 @@ echo "*"
 echo "* AWS OFI NCCL plugin has been configured."
 echo "*"
 echo "* Enabled Platforms: ${ENABLED_PLATFORMS}"
+echo "* GoogleTest mock build: ${have_gtest}"
 echo "*"

--- a/m4/check_pkg_gtest.m4
+++ b/m4/check_pkg_gtest.m4
@@ -1,0 +1,64 @@
+# CHECK_PKG_GTEST([action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([CHECK_PKG_GTEST], [
+    AC_ARG_WITH([gtest],
+        [AS_HELP_STRING([--with-gtest=PATH],
+            [Path to GoogleTest installation])],
+        [gtest_path="$withval"],
+        [gtest_path=""])
+
+    AC_ARG_ENABLE([gtest],
+        [AS_HELP_STRING([--enable-gtest],
+            [Enable GoogleTest/GoogleMock unit tests (default: no)])],
+        [enable_gtest="$enableval"],
+        [enable_gtest="no"])
+
+    have_gtest=no
+    GTEST_CPPFLAGS=""
+    GTEST_LDFLAGS=""
+    GTEST_LIBS=""
+
+    AS_IF([test "x$enable_gtest" != "xno"], [
+        save_CPPFLAGS="$CPPFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+        save_LIBS="$LIBS"
+
+        AS_IF([test "x$gtest_path" != "x"], [
+            GTEST_CPPFLAGS="-I$gtest_path/include"
+            GTEST_LDFLAGS="-L$gtest_path/lib"
+        ])
+
+        CPPFLAGS="$CPPFLAGS $GTEST_CPPFLAGS"
+        LDFLAGS="$LDFLAGS $GTEST_LDFLAGS"
+
+        AC_CHECK_HEADERS([gtest/gtest.h gmock/gmock.h], [
+            AC_CHECK_LIB([gtest], [main], [
+                AC_CHECK_LIB([gmock], [main], [
+                    have_gtest=yes
+                    GTEST_LIBS="-lgtest -lgmock -lpthread"
+                ], [], [-lgtest -lpthread])
+            ], [], [-lpthread])
+        ])
+
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+        LIBS="$save_LIBS"
+
+        AS_IF([test "x$have_gtest" = "xyes"], [
+            AC_MSG_NOTICE([GoogleTest/GoogleMock found])
+            $1
+        ], [
+            AS_IF([test "x$enable_gtest" = "xyes"], [
+                AC_MSG_ERROR([GoogleTest/GoogleMock requested but not found])
+            ], [
+                AC_MSG_NOTICE([GoogleTest/GoogleMock not found, disabling GoogleTest tests])
+            ])
+            $2
+        ])
+    ])
+
+    AC_SUBST([GTEST_CPPFLAGS])
+    AC_SUBST([GTEST_LDFLAGS])
+    AC_SUBST([GTEST_LIBS])
+    AM_CONDITIONAL([ENABLE_GTEST], [test "x$have_gtest" = "xyes"])
+])

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -14,3 +14,5 @@ dlopen_c_test
 param
 platform_manager
 gdrcopy
+libfabric_mock_test
+core.*

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -16,3 +16,4 @@ platform_manager
 gdrcopy
 libfabric_mock_test
 core.*
+ofiutils_get_providers_test

--- a/tests/unit/GTEST_README.md
+++ b/tests/unit/GTEST_README.md
@@ -1,0 +1,596 @@
+# GoogleTest/GoogleMock Unit Testing Framework
+
+This directory contains GoogleTest/GoogleMock-based unit tests with complete libfabric API mocking for aws-ofi-nccl.
+
+## Table of Contents
+
+- [References](#references)
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Architecture](#architecture)
+- [Writing Tests](#writing-tests)
+- [Adding New Mocks](#adding-new-mocks)
+- [Troubleshooting](#troubleshooting)
+- [Technical Details](#technical-details)
+
+
+## References
+
+- [GoogleTest Documentation](https://google.github.io/googletest/)
+- [GoogleMock Cheat Sheet](https://google.github.io/googletest/gmock_cheat_sheet.html)
+- [GCC Linker Options](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html)
+- [Libfabric Documentation](https://ofiwg.github.io/libfabric/)
+
+---
+
+## Overview
+
+The GoogleTest framework provides:
+- **Complete libfabric mocking** - All 37 libfabric APIs used by aws-ofi-nccl
+- **Argument verification** - Verify exact parameters passed to libfabric functions
+- **Isolated testing** - Test aws-ofi-nccl code without actual libfabric or hardware
+- **Inline function handling** - Properly mocks `static inline` libfabric functions using linker wrapping
+
+### What's Mocked
+
+**37 libfabric functions across 7 categories:**
+
+| Category | Functions |
+|----------|-----------|
+| **Initialization** | `fi_getinfo`, `fi_freeinfo`, `fi_dupinfo`, `fi_allocinfo`, `fi_fabric`, `fi_domain`, `fi_endpoint` |
+| **Memory Registration** | `fi_mr_regattr`, `fi_mr_bind`, `fi_mr_enable`, `fi_mr_desc`, `fi_mr_key` |
+| **Endpoint Operations** | `fi_ep_bind`, `fi_enable`, `fi_close`, `fi_getname`, `fi_setopt`, `fi_getopt` |
+| **Data Transfer** | `fi_send`, `fi_recv`, `fi_senddata`, `fi_recvmsg`, `fi_tsend`, `fi_trecv` |
+| **RMA Operations** | `fi_read`, `fi_write`, `fi_writedata`, `fi_writemsg` |
+| **Completion Queue** | `fi_cq_open`, `fi_cq_read`, `fi_cq_readfrom`, `fi_cq_readerr`, `fi_cq_strerror` |
+| **Address Vector** | `fi_av_open`, `fi_av_insert` |
+| **Utilities** | `fi_strerror`, `fi_version` |
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+Install GoogleTest and GoogleMock:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libgtest-dev libgmock-dev
+
+# Amazon Linux 2023
+sudo yum install gtest-devel gmock-devel
+
+# From source
+git clone https://github.com/google/googletest.git
+cd googletest && mkdir build && cd build
+cmake .. && make && sudo make install
+```
+
+### Building with GoogleTest
+
+```bash
+./autogen.sh
+./configure --enable-gtest --with-libfabric=/opt/amazon/efa --with-cuda=/usr/local/cuda
+make
+make check
+```
+
+To specify custom GoogleTest location:
+```bash
+./configure --enable-gtest --with-gtest=/path/to/gtest
+```
+
+### Running Tests
+
+```bash
+# Run all tests (including GoogleTest)
+make check
+
+# Run only the libfabric mock test
+./tests/unit/libfabric_mock_test
+
+# Run with verbose output
+./tests/unit/libfabric_mock_test --gtest_verbose
+```
+
+---
+
+## Architecture
+
+### The Inline Function Challenge
+
+Libfabric defines most functions as `static inline` in headers:
+
+```c
+// From libfabric headers
+static inline ssize_t fi_send(struct fid_ep *ep, const void *buf, ...) {
+    return ep->msg->send(ep, buf, ...);  // Calls function pointer
+}
+```
+
+**Problem:** You cannot override inline functions with traditional mocking because they're expanded at compile time.
+
+**Solution:** Use GCC's `--wrap` linker flag to intercept calls at link time:
+
+```
+Test Code                Linker              Mock Implementation
+─────────               ───────             ────────────────────
+fi_send()    ──────>    --wrap=fi_send ──>  __wrap_fi_send()
+                                                    │
+                                                    ▼
+                                            g_libfabric_mock->fi_send()
+```
+
+### Framework Components
+
+```
+tests/unit/
+├── libfabric_mock.h           # Mock class with MOCK_METHOD declarations
+├── libfabric_mock_impl.cpp    # C wrapper functions delegating to mock
+├── libfabric_mock_test.cpp    # Example tests demonstrating usage
+├── GTEST_README.md            # This file
+└── Makefile.am                # Build configuration with --wrap flags
+```
+
+**Flow:**
+1. Test sets expectation: `EXPECT_CALL(*mock, fi_domain(...))`
+2. Test calls Plugin Functions: `nccl_ofi_ofiutils_domain_create(...)`
+3. Plugin Functions Call Libfabric Funtions: `fi_domain(...)`
+3. Linker redirects to: `__wrap_fi_domain(...)`
+4. Wrapper calls: `g_libfabric_mock->fi_domain(...)`
+5. GoogleMock verifies and returns mocked value
+
+---
+
+## Writing Tests
+
+### Basic Test Structure
+
+```cpp
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "libfabric_mock.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
+
+class MyComponentTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock = new ::testing::NiceMock<LibfabricMock>();
+        g_libfabric_mock = mock;
+    }
+
+    void TearDown() override {
+        delete mock;
+        g_libfabric_mock = nullptr;
+    }
+
+    LibfabricMock* mock;
+};
+
+TEST_F(MyComponentTest, TestSomething) {
+    // Set expectations
+    EXPECT_CALL(*mock, fi_version())
+        .WillOnce(Return(FI_VERSION(1, 20)));
+
+    // Call code under test
+    uint32_t version = fi_version();
+
+    // Verify
+    EXPECT_EQ(version, FI_VERSION(1, 20));
+}
+```
+
+### Example: Testing fi_getinfo
+
+```cpp
+TEST_F(MyComponentTest, GetinfoReturnsProviderInfo) {
+    struct fi_info* mock_info = reinterpret_cast<struct fi_info*>(0x1234);
+    struct fi_info hints = {};
+    struct fi_info* result = nullptr;
+
+    // Expect fi_getinfo to be called with specific parameters
+    EXPECT_CALL(*mock, fi_getinfo(
+        FI_VERSION(1, 18),  // version
+        nullptr,            // node
+        nullptr,            // service
+        0ULL,              // flags
+        _,                 // hints (any)
+        _                  // info (output)
+    ))
+    .WillOnce(DoAll(
+        SetArgPointee<5>(mock_info),  // Set output parameter
+        Return(0)                      // Return success
+    ));
+
+    int rc = fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, &hints, &result);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(result, mock_info);
+}
+```
+
+### Example: Verifying Exact Arguments
+
+```cpp
+TEST_F(MyComponentTest, SendUsesCorrectBuffer) {
+    struct fid_ep ep = {};
+    const char* expected_buffer = "test data";
+    size_t expected_len = 9;
+
+    // Verify exact arguments
+    EXPECT_CALL(*mock, fi_send(
+        &ep,                    // Exact pointer
+        expected_buffer,        // Exact buffer
+        expected_len,           // Exact length
+        _,                      // Any descriptor
+        42,                     // Exact destination
+        _                       // Any context
+    ))
+    .WillOnce(Return(0));
+
+    // This will only pass if arguments match exactly
+    ssize_t rc = fi_send(&ep, expected_buffer, expected_len, nullptr, 42, nullptr);
+    EXPECT_EQ(rc, 0);
+}
+```
+
+### Example: Testing Error Paths
+
+```cpp
+TEST_F(MyComponentTest, HandlesGetinfoFailure) {
+    EXPECT_CALL(*mock, fi_getinfo(_, _, _, _, _, _))
+        .WillOnce(Return(-FI_ENODATA));
+
+    EXPECT_CALL(*mock, fi_strerror(-FI_ENODATA))
+        .WillOnce(Return("No data available"));
+
+    struct fi_info* result = nullptr;
+    int rc = fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0, nullptr, &result);
+
+    EXPECT_EQ(rc, -FI_ENODATA);
+    EXPECT_STREQ(fi_strerror(rc), "No data available");
+}
+```
+
+### Example: Testing Sequence of Calls
+
+```cpp
+TEST_F(MyComponentTest, InitializationSequence) {
+    using ::testing::InSequence;
+    InSequence seq;  // Enforce call order
+
+    EXPECT_CALL(*mock, fi_getinfo(_, _, _, _, _, _))
+        .WillOnce(Return(0));
+    EXPECT_CALL(*mock, fi_fabric(_, _, _))
+        .WillOnce(Return(0));
+    EXPECT_CALL(*mock, fi_domain(_, _, _, _))
+        .WillOnce(Return(0));
+    EXPECT_CALL(*mock, fi_endpoint(_, _, _, _))
+        .WillOnce(Return(0));
+
+    // Code must call functions in this exact order
+    my_initialization_function();
+}
+```
+
+### Adding Your Test to Build System
+
+Edit `tests/unit/Makefile.am`:
+
+```makefile
+if ENABLE_GTEST
+noinst_PROGRAMS += libfabric_mock_test my_new_test
+
+my_new_test_SOURCES = my_new_test.cpp libfabric_mock_impl.cpp
+my_new_test_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_CPPFLAGS)
+my_new_test_CXXFLAGS = -Wno-error
+my_new_test_LDADD = $(GTEST_LIBS)
+my_new_test_LDFLAGS = $(GTEST_LDFLAGS) \
+    -Wl,--wrap=fi_send,--wrap=fi_recv,...  # Copy from libfabric_mock_test
+endif
+```
+
+---
+
+## Adding New Mocks
+
+### When to Add a New Mock
+
+Add a mock when:
+1. You're testing code that calls a new libfabric function
+2. The function isn't in the current mock list (see [Overview](#overview))
+
+### Step 1: Add to Mock Header
+
+Edit `tests/unit/libfabric_mock.h`:
+
+```cpp
+class LibfabricMock {
+public:
+    virtual ~LibfabricMock() = default;
+
+    // ... existing mocks ...
+
+    // Add your new mock
+    MOCK_METHOD(int, fi_new_function,
+        (struct fid_domain *domain, int param, void **output));
+};
+```
+
+**Parameter types must match libfabric exactly.**
+
+### Step 2: Determine if Function is Inline
+
+Check libfabric headers:
+
+```bash
+grep -r "fi_new_function" /opt/amazon/efa/include/rdma/
+```
+
+Look for `static inline` in the definition.
+
+### Step 3A: If Non-Inline Function
+
+Add regular definition to `libfabric_mock_impl.cpp`:
+
+```cpp
+extern "C" {
+
+// ... existing functions ...
+
+int fi_new_function(struct fid_domain *domain, int param, void **output)
+{
+    return g_libfabric_mock->fi_new_function(domain, param, output);
+}
+
+} // extern "C"
+```
+
+### Step 3B: If Inline Function
+
+**Add forward declaration:**
+
+```cpp
+// Forward declarations for wrapped inline functions
+extern "C" {
+// ... existing declarations ...
+int __wrap_fi_new_function(struct fid_domain*, int, void**);
+}
+```
+
+**Add wrapped implementation:**
+
+```cpp
+// Inline functions - wrapped definitions
+// ... existing wrapped functions ...
+
+int __wrap_fi_new_function(struct fid_domain *domain, int param, void **output)
+{
+    return g_libfabric_mock->fi_new_function(domain, param, output);
+}
+```
+
+**Add to linker wrap flags in `Makefile.am`:**
+
+```makefile
+libfabric_mock_test_LDFLAGS = $(GTEST_LDFLAGS) \
+    -Wl,--wrap=fi_send,...,--wrap=fi_new_function
+```
+
+### Step 4: Rebuild
+
+```bash
+./autogen.sh
+./configure --enable-gtest --with-libfabric=/opt/amazon/efa
+make clean
+make
+```
+
+### Step 5: Write Test
+
+```cpp
+TEST_F(MyTest, NewFunctionWorks) {
+    struct fid_domain domain = {};
+    void* output = reinterpret_cast<void*>(0x5678);
+
+    EXPECT_CALL(*mock, fi_new_function(&domain, 42, _))
+        .WillOnce(DoAll(
+            SetArgPointee<2>(output),
+            Return(0)
+        ));
+
+    void* result = nullptr;
+    int rc = fi_new_function(&domain, 42, &result);
+
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(result, output);
+}
+```
+
+---
+
+## Troubleshooting
+
+### Build Errors
+
+#### "undefined reference to `fi_*`"
+
+**Cause:** Function not wrapped or not in mock implementation.
+
+**Fix:** Add function to `libfabric_mock_impl.cpp` and `--wrap` flags in `Makefile.am`.
+
+#### "redefinition of `fi_*`"
+
+**Cause:** Inline function defined in both mock and libfabric headers.
+
+**Fix:**
+1. Remove regular definition from `libfabric_mock_impl.cpp`
+2. Add `__wrap_fi_*` version instead
+3. Add to `--wrap` flags in `Makefile.am`
+
+#### "no previous declaration for `__wrap_fi_*`"
+
+**Cause:** Missing forward declaration for wrapped function.
+
+**Fix:** Add forward declaration in `libfabric_mock_impl.cpp`:
+```cpp
+extern "C" {
+int __wrap_fi_your_function(...);
+}
+```
+
+### Runtime Errors
+
+#### "Uninteresting mock function call"
+
+**Cause:** Function called without `EXPECT_CALL` set up.
+
+**Fix:** Either:
+1. Add `EXPECT_CALL` for the function
+2. Use `NiceMock<LibfabricMock>` (already default in test fixture)
+
+#### Test Hangs
+
+**Cause:** Infinite loop or deadlock in code under test.
+
+**Fix:** Run with timeout:
+```bash
+timeout 5 ./tests/unit/my_test
+```
+
+### GoogleTest Not Found
+
+```
+configure: GoogleTest/GoogleMock not found
+```
+
+**Fix:**
+```bash
+# Install packages
+sudo apt-get install libgtest-dev libgmock-dev
+
+# Or specify path
+./configure --enable-gtest --with-gtest=/usr/local
+```
+
+---
+
+## Technical Details
+
+### Why Linker Wrapping?
+
+**Alternative approaches and why they don't work:**
+
+| Approach | Why It Doesn't Work |
+|----------|---------------------|
+| **Direct mocking** | Inline functions expanded at compile time, can't override |
+| **LD_PRELOAD** | Doesn't intercept inline functions, only shared library calls |
+| **Mocking ops structures** | Requires creating dozens of mock structures, fragile and complex |
+| **Preprocessor tricks** | Breaks type safety, hard to maintain |
+
+**Linker wrapping works because:**
+- Operates at link time (after inline expansion)
+- Clean, maintainable approach
+- Preserves type safety
+- Standard GCC feature
+
+### Inline vs Non-Inline Functions
+
+**Non-inline (6 functions):**
+- Actual function symbols in libfabric library
+- Can be mocked with regular definitions
+- Examples: `fi_getinfo`, `fi_freeinfo`, `fi_strerror`
+
+**Inline (31 functions):**
+- Defined in headers, expanded at compile time
+- Must use `--wrap` to intercept
+- Examples: `fi_send`, `fi_recv`, `fi_read`, `fi_write`
+
+### Linker Wrap Mechanism
+
+When you compile with `-Wl,--wrap=fi_send`:
+
+1. **Compile time:** `fi_send()` call compiled normally
+2. **Link time:** Linker sees `--wrap=fi_send` flag
+3. **Linker action:**
+   - Renames `fi_send` symbol to `__wrap_fi_send`
+   - Renames `__real_fi_send` to `fi_send` (if it exists)
+4. **Result:** All calls to `fi_send` go to `__wrap_fi_send`
+
+### Mock Lifecycle
+
+```cpp
+SetUp() {
+    mock = new NiceMock<LibfabricMock>();  // Create mock
+    g_libfabric_mock = mock;                // Set global pointer
+}
+
+TEST_F(...) {
+    EXPECT_CALL(*mock, fi_send(...));       // Set expectation
+    my_function();                          // Calls fi_send
+    // GoogleMock verifies expectation
+}
+
+TearDown() {
+    delete mock;                            // Destroy mock
+    g_libfabric_mock = nullptr;            // Clear global pointer
+}
+```
+
+### GoogleMock Matchers
+
+Common matchers for libfabric functions:
+
+```cpp
+using ::testing::_;           // Any value
+using ::testing::Eq;          // Equal to
+using ::testing::Ne;          // Not equal to
+using ::testing::Gt;          // Greater than
+using ::testing::NotNull;     // Not NULL pointer
+using ::testing::IsNull;      // NULL pointer
+using ::testing::Pointee;     // Dereference and match
+
+EXPECT_CALL(*mock, fi_send(
+    NotNull(),                // ep must not be NULL
+    _,                        // buffer can be anything
+    Gt(0),                    // length must be > 0
+    _,                        // desc can be anything
+    Ne(FI_ADDR_UNSPEC),      // dest must be specified
+    _                         // context can be anything
+));
+```
+
+### Actions
+
+Common actions for return values:
+
+```cpp
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
+using ::testing::Invoke;
+
+// Return simple value
+.WillOnce(Return(0))
+
+// Set output parameter
+.WillOnce(DoAll(
+    SetArgPointee<5>(mock_info),  // 6th parameter (0-indexed)
+    Return(0)
+))
+
+// Call custom function
+.WillOnce(Invoke([](auto...) { return 0; }))
+
+// Multiple calls
+.WillOnce(Return(-1))
+.WillOnce(Return(0))
+.WillRepeatedly(Return(0))
+```
+
+---

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -13,6 +13,11 @@ AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/inc
 LDADD = $(top_builddir)/src/libinternal_plugin.la
 noinst_HEADERS = test-logger.h
 
+if ENABLE_GTEST
+AM_CPPFLAGS += $(GTEST_CPPFLAGS)
+noinst_HEADERS += libfabric_mock.h
+endif
+
 noinst_PROGRAMS = \
 	assert \
 	environ \
@@ -27,6 +32,28 @@ noinst_PROGRAMS = \
 	dlopen_c_test \
 	param \
 	platform_manager
+
+if ENABLE_GTEST
+# Linker flags to wrap all mocked inline libfabric functions.
+# Add new --wrap entries here when extending the mock.
+GTEST_MOCK_WRAP_FLAGS = \
+	-Wl,--wrap=fi_allocinfo,--wrap=fi_fabric,--wrap=fi_domain,--wrap=fi_endpoint \
+	-Wl,--wrap=fi_close,--wrap=fi_enable,--wrap=fi_ep_bind \
+	-Wl,--wrap=fi_mr_bind,--wrap=fi_mr_desc,--wrap=fi_mr_enable,--wrap=fi_mr_key,--wrap=fi_mr_regattr \
+	-Wl,--wrap=fi_av_insert,--wrap=fi_av_open \
+	-Wl,--wrap=fi_cq_open,--wrap=fi_cq_read,--wrap=fi_cq_readfrom,--wrap=fi_cq_readerr,--wrap=fi_cq_strerror \
+	-Wl,--wrap=fi_send,--wrap=fi_recv,--wrap=fi_senddata,--wrap=fi_recvmsg \
+	-Wl,--wrap=fi_tsend,--wrap=fi_trecv \
+	-Wl,--wrap=fi_read,--wrap=fi_write,--wrap=fi_writedata,--wrap=fi_writemsg \
+	-Wl,--wrap=fi_setopt,--wrap=fi_getopt,--wrap=fi_getname
+
+noinst_PROGRAMS += libfabric_mock_test
+libfabric_mock_test_SOURCES = libfabric_mock_test.cpp libfabric_mock_impl.cpp
+libfabric_mock_test_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_CPPFLAGS)
+libfabric_mock_test_CXXFLAGS = -Wno-error
+libfabric_mock_test_LDADD = $(GTEST_LIBS)
+libfabric_mock_test_LDFLAGS = $(GTEST_LDFLAGS) $(GTEST_MOCK_WRAP_FLAGS)
+endif
 
 if WANT_PLATFORM_AWS
 noinst_PROGRAMS += aws_platform_mapper

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -53,6 +53,14 @@ libfabric_mock_test_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_CPPFLAGS)
 libfabric_mock_test_CXXFLAGS = -Wno-error
 libfabric_mock_test_LDADD = $(GTEST_LIBS)
 libfabric_mock_test_LDFLAGS = $(GTEST_LDFLAGS) $(GTEST_MOCK_WRAP_FLAGS)
+
+noinst_PROGRAMS += ofiutils_get_providers_test
+ofiutils_get_providers_test_SOURCES = ofiutils_get_providers_test.cpp libfabric_mock_impl.cpp \
+	$(top_srcdir)/src/nccl_ofi_ofiutils.cpp
+ofiutils_get_providers_test_CPPFLAGS = $(AM_CPPFLAGS) $(GTEST_CPPFLAGS)
+ofiutils_get_providers_test_CXXFLAGS = -Wno-error
+ofiutils_get_providers_test_LDADD = $(GTEST_LIBS)
+ofiutils_get_providers_test_LDFLAGS = $(GTEST_LDFLAGS) $(GTEST_MOCK_WRAP_FLAGS)
 endif
 
 if WANT_PLATFORM_AWS

--- a/tests/unit/libfabric_mock.h
+++ b/tests/unit/libfabric_mock.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef LIBFABRIC_MOCK_H
+#define LIBFABRIC_MOCK_H
+
+#include <gmock/gmock.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_errno.h>
+
+class LibfabricMock {
+public:
+	virtual ~LibfabricMock() = default;
+
+	MOCK_METHOD(int, fi_getinfo, (uint32_t version, const char *node, const char *service,
+		uint64_t flags, const struct fi_info *hints, struct fi_info **info));
+	MOCK_METHOD(void, fi_freeinfo, (struct fi_info *info));
+	MOCK_METHOD(struct fi_info*, fi_dupinfo, (const struct fi_info *info));
+	MOCK_METHOD(struct fi_info*, fi_allocinfo, ());
+	MOCK_METHOD(int, fi_fabric, (struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context));
+	MOCK_METHOD(int, fi_domain, (struct fid_fabric *fabric, struct fi_info *info,
+		struct fid_domain **domain, void *context));
+	MOCK_METHOD(int, fi_endpoint, (struct fid_domain *domain, struct fi_info *info,
+		struct fid_ep **ep, void *context));
+	MOCK_METHOD(int, fi_av_open, (struct fid_domain *domain, struct fi_av_attr *attr,
+		struct fid_av **av, void *context));
+	MOCK_METHOD(int, fi_cq_open, (struct fid_domain *domain, struct fi_cq_attr *attr,
+		struct fid_cq **cq, void *context));
+	MOCK_METHOD(int, fi_mr_regattr, (struct fid_domain *domain, const struct fi_mr_attr *attr,
+		uint64_t flags, struct fid_mr **mr));
+	MOCK_METHOD(int, fi_close, (struct fid *fid));
+	MOCK_METHOD(int, fi_ep_bind, (struct fid_ep *ep, struct fid *bfid, uint64_t flags));
+	MOCK_METHOD(int, fi_enable, (struct fid_ep *ep));
+	MOCK_METHOD(int, fi_mr_bind, (struct fid_mr *mr, struct fid *bfid, uint64_t flags));
+	MOCK_METHOD(int, fi_mr_enable, (struct fid_mr *mr));
+	MOCK_METHOD(void*, fi_mr_desc, (struct fid_mr *mr));
+	MOCK_METHOD(uint64_t, fi_mr_key, (struct fid_mr *mr));
+	MOCK_METHOD(int, fi_av_insert, (struct fid_av *av, const void *addr, size_t count,
+		fi_addr_t *fi_addr, uint64_t flags, void *context));
+	MOCK_METHOD(int, fi_getname, (fid_t fid, void *addr, size_t *addrlen));
+	MOCK_METHOD(int, fi_setopt, (fid_t fid, int level, int optname, const void *optval, size_t optlen));
+	MOCK_METHOD(int, fi_getopt, (fid_t fid, int level, int optname, void *optval, size_t *optlen));
+	MOCK_METHOD(ssize_t, fi_send, (struct fid_ep *ep, const void *buf, size_t len,
+		void *desc, fi_addr_t dest_addr, void *context));
+	MOCK_METHOD(ssize_t, fi_recv, (struct fid_ep *ep, void *buf, size_t len,
+		void *desc, fi_addr_t src_addr, void *context));
+	MOCK_METHOD(ssize_t, fi_senddata, (struct fid_ep *ep, const void *buf, size_t len,
+		void *desc, uint64_t data, fi_addr_t dest_addr, void *context));
+	MOCK_METHOD(ssize_t, fi_recvmsg, (struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags));
+	MOCK_METHOD(ssize_t, fi_tsend, (struct fid_ep *ep, const void *buf, size_t len,
+		void *desc, fi_addr_t dest_addr, uint64_t tag, void *context));
+	MOCK_METHOD(ssize_t, fi_trecv, (struct fid_ep *ep, void *buf, size_t len,
+		void *desc, fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context));
+	MOCK_METHOD(ssize_t, fi_read, (struct fid_ep *ep, void *buf, size_t len,
+		void *desc, fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context));
+	MOCK_METHOD(ssize_t, fi_write, (struct fid_ep *ep, const void *buf, size_t len,
+		void *desc, fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context));
+	MOCK_METHOD(ssize_t, fi_writedata, (struct fid_ep *ep, const void *buf, size_t len,
+		void *desc, uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context));
+	MOCK_METHOD(ssize_t, fi_writemsg, (struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_t flags));
+	MOCK_METHOD(ssize_t, fi_cq_read, (struct fid_cq *cq, void *buf, size_t count));
+	MOCK_METHOD(ssize_t, fi_cq_readfrom, (struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr));
+	MOCK_METHOD(ssize_t, fi_cq_readerr, (struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags));
+	MOCK_METHOD(const char*, fi_cq_strerror, (struct fid_cq *cq, int prov_errno,
+		const void *err_data, char *buf, size_t len));
+	MOCK_METHOD(const char*, fi_strerror, (int errnum));
+	MOCK_METHOD(uint32_t, fi_version, ());
+};
+
+extern LibfabricMock* g_libfabric_mock;
+
+#endif // LIBFABRIC_MOCK_H

--- a/tests/unit/libfabric_mock_impl.cpp
+++ b/tests/unit/libfabric_mock_impl.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "libfabric_mock.h"
+#include <cstddef>
+
+LibfabricMock* g_libfabric_mock = nullptr;
+
+// Forward declarations for wrapped inline functions
+extern "C" {
+struct fi_info* __wrap_fi_allocinfo();
+int __wrap_fi_fabric(struct fi_fabric_attr*, struct fid_fabric**, void*);
+int __wrap_fi_domain(struct fid_fabric*, struct fi_info*, struct fid_domain**, void*);
+int __wrap_fi_endpoint(struct fid_domain*, struct fi_info*, struct fid_ep**, void*);
+int __wrap_fi_close(struct fid*);
+int __wrap_fi_enable(struct fid_ep*);
+int __wrap_fi_ep_bind(struct fid_ep*, struct fid*, uint64_t);
+int __wrap_fi_mr_bind(struct fid_mr*, struct fid*, uint64_t);
+int __wrap_fi_mr_enable(struct fid_mr*);
+int __wrap_fi_mr_regattr(struct fid_domain*, const struct fi_mr_attr*, uint64_t, struct fid_mr**);
+void* __wrap_fi_mr_desc(struct fid_mr*);
+uint64_t __wrap_fi_mr_key(struct fid_mr*);
+int __wrap_fi_av_insert(struct fid_av*, const void*, size_t, fi_addr_t*, uint64_t, void*);
+int __wrap_fi_av_open(struct fid_domain*, struct fi_av_attr*, struct fid_av**, void*);
+int __wrap_fi_cq_open(struct fid_domain*, struct fi_cq_attr*, struct fid_cq**, void*);
+int __wrap_fi_getname(fid_t, void*, size_t*);
+int __wrap_fi_setopt(fid_t, int, int, const void*, size_t);
+int __wrap_fi_getopt(fid_t, int, int, void*, size_t*);
+ssize_t __wrap_fi_send(struct fid_ep*, const void*, size_t, void*, fi_addr_t, void*);
+ssize_t __wrap_fi_recv(struct fid_ep*, void*, size_t, void*, fi_addr_t, void*);
+ssize_t __wrap_fi_senddata(struct fid_ep*, const void*, size_t, void*, uint64_t, fi_addr_t, void*);
+ssize_t __wrap_fi_recvmsg(struct fid_ep*, const struct fi_msg*, uint64_t);
+ssize_t __wrap_fi_tsend(struct fid_ep*, const void*, size_t, void*, fi_addr_t, uint64_t, void*);
+ssize_t __wrap_fi_trecv(struct fid_ep*, void*, size_t, void*, fi_addr_t, uint64_t, uint64_t, void*);
+ssize_t __wrap_fi_read(struct fid_ep*, void*, size_t, void*, fi_addr_t, uint64_t, uint64_t, void*);
+ssize_t __wrap_fi_write(struct fid_ep*, const void*, size_t, void*, fi_addr_t, uint64_t, uint64_t, void*);
+ssize_t __wrap_fi_writedata(struct fid_ep*, const void*, size_t, void*, uint64_t, fi_addr_t, uint64_t, uint64_t, void*);
+ssize_t __wrap_fi_writemsg(struct fid_ep*, const struct fi_msg_rma*, uint64_t);
+ssize_t __wrap_fi_cq_read(struct fid_cq*, void*, size_t);
+ssize_t __wrap_fi_cq_readfrom(struct fid_cq*, void*, size_t, fi_addr_t*);
+ssize_t __wrap_fi_cq_readerr(struct fid_cq*, struct fi_cq_err_entry*, uint64_t);
+const char* __wrap_fi_cq_strerror(struct fid_cq*, int, const void*, char*, size_t);
+}
+
+extern "C" {
+
+// Non-inline functions - regular definitions
+int fi_getinfo(uint32_t version, const char *node, const char *service,
+	uint64_t flags, const struct fi_info *hints, struct fi_info **info)
+{
+	return g_libfabric_mock->fi_getinfo(version, node, service, flags, hints, info);
+}
+
+void fi_freeinfo(struct fi_info *info)
+{
+	g_libfabric_mock->fi_freeinfo(info);
+}
+
+struct fi_info* fi_dupinfo(const struct fi_info *info)
+{
+	return g_libfabric_mock->fi_dupinfo(info);
+}
+
+const char* fi_strerror(int errnum)
+{
+	return g_libfabric_mock->fi_strerror(errnum);
+}
+
+uint32_t fi_version()
+{
+	return g_libfabric_mock->fi_version();
+}
+
+// Inline functions - wrapped definitions
+struct fi_info* __wrap_fi_allocinfo()
+{
+	return g_libfabric_mock->fi_allocinfo();
+}
+
+int __wrap_fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
+{
+	return g_libfabric_mock->fi_fabric(attr, fabric, context);
+}
+
+int __wrap_fi_domain(struct fid_fabric *fabric, struct fi_info *info,
+	struct fid_domain **domain, void *context)
+{
+	return g_libfabric_mock->fi_domain(fabric, info, domain, context);
+}
+
+int __wrap_fi_endpoint(struct fid_domain *domain, struct fi_info *info,
+	struct fid_ep **ep, void *context)
+{
+	return g_libfabric_mock->fi_endpoint(domain, info, ep, context);
+}
+
+int __wrap_fi_close(struct fid *fid)
+{
+	return g_libfabric_mock->fi_close(fid);
+}
+
+int __wrap_fi_enable(struct fid_ep *ep)
+{
+	return g_libfabric_mock->fi_enable(ep);
+}
+
+int __wrap_fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags)
+{
+	return g_libfabric_mock->fi_ep_bind(ep, bfid, flags);
+}
+
+int __wrap_fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags)
+{
+	return g_libfabric_mock->fi_mr_bind(mr, bfid, flags);
+}
+
+int __wrap_fi_mr_enable(struct fid_mr *mr)
+{
+	return g_libfabric_mock->fi_mr_enable(mr);
+}
+
+int __wrap_fi_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+	uint64_t flags, struct fid_mr **mr)
+{
+	return g_libfabric_mock->fi_mr_regattr(domain, attr, flags, mr);
+}
+
+void* __wrap_fi_mr_desc(struct fid_mr *mr)
+{
+	return g_libfabric_mock->fi_mr_desc(mr);
+}
+
+uint64_t __wrap_fi_mr_key(struct fid_mr *mr)
+{
+	return g_libfabric_mock->fi_mr_key(mr);
+}
+
+int __wrap_fi_av_insert(struct fid_av *av, const void *addr, size_t count,
+	fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	return g_libfabric_mock->fi_av_insert(av, addr, count, fi_addr, flags, context);
+}
+
+int __wrap_fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+	struct fid_av **av, void *context)
+{
+	return g_libfabric_mock->fi_av_open(domain, attr, av, context);
+}
+
+int __wrap_fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+	struct fid_cq **cq, void *context)
+{
+	return g_libfabric_mock->fi_cq_open(domain, attr, cq, context);
+}
+
+int __wrap_fi_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	return g_libfabric_mock->fi_getname(fid, addr, addrlen);
+}
+
+int __wrap_fi_setopt(fid_t fid, int level, int optname, const void *optval, size_t optlen)
+{
+	return g_libfabric_mock->fi_setopt(fid, level, optname, optval, optlen);
+}
+
+int __wrap_fi_getopt(fid_t fid, int level, int optname, void *optval, size_t *optlen)
+{
+	return g_libfabric_mock->fi_getopt(fid, level, optname, optval, optlen);
+}
+
+ssize_t __wrap_fi_send(struct fid_ep *ep, const void *buf, size_t len,
+	void *desc, fi_addr_t dest_addr, void *context)
+{
+	return g_libfabric_mock->fi_send(ep, buf, len, desc, dest_addr, context);
+}
+
+ssize_t __wrap_fi_recv(struct fid_ep *ep, void *buf, size_t len,
+	void *desc, fi_addr_t src_addr, void *context)
+{
+	return g_libfabric_mock->fi_recv(ep, buf, len, desc, src_addr, context);
+}
+
+ssize_t __wrap_fi_senddata(struct fid_ep *ep, const void *buf, size_t len,
+	void *desc, uint64_t data, fi_addr_t dest_addr, void *context)
+{
+	return g_libfabric_mock->fi_senddata(ep, buf, len, desc, data, dest_addr, context);
+}
+
+ssize_t __wrap_fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+{
+	return g_libfabric_mock->fi_recvmsg(ep, msg, flags);
+}
+
+ssize_t __wrap_fi_tsend(struct fid_ep *ep, const void *buf, size_t len,
+	void *desc, fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	return g_libfabric_mock->fi_tsend(ep, buf, len, desc, dest_addr, tag, context);
+}
+
+ssize_t __wrap_fi_trecv(struct fid_ep *ep, void *buf, size_t len,
+	void *desc, fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
+{
+	return g_libfabric_mock->fi_trecv(ep, buf, len, desc, src_addr, tag, ignore, context);
+}
+
+ssize_t __wrap_fi_read(struct fid_ep *ep, void *buf, size_t len,
+	void *desc, fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+{
+	return g_libfabric_mock->fi_read(ep, buf, len, desc, src_addr, addr, key, context);
+}
+
+ssize_t __wrap_fi_write(struct fid_ep *ep, const void *buf, size_t len,
+	void *desc, fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+{
+	return g_libfabric_mock->fi_write(ep, buf, len, desc, dest_addr, addr, key, context);
+}
+
+ssize_t __wrap_fi_writedata(struct fid_ep *ep, const void *buf, size_t len,
+	void *desc, uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+{
+	return g_libfabric_mock->fi_writedata(ep, buf, len, desc, data, dest_addr, addr, key, context);
+}
+
+ssize_t __wrap_fi_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
+{
+	return g_libfabric_mock->fi_writemsg(ep, msg, flags);
+}
+
+ssize_t __wrap_fi_cq_read(struct fid_cq *cq, void *buf, size_t count)
+{
+	return g_libfabric_mock->fi_cq_read(cq, buf, count);
+}
+
+ssize_t __wrap_fi_cq_readfrom(struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr)
+{
+	return g_libfabric_mock->fi_cq_readfrom(cq, buf, count, src_addr);
+}
+
+ssize_t __wrap_fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags)
+{
+	return g_libfabric_mock->fi_cq_readerr(cq, buf, flags);
+}
+
+const char* __wrap_fi_cq_strerror(struct fid_cq *cq, int prov_errno,
+	const void *err_data, char *buf, size_t len)
+{
+	return g_libfabric_mock->fi_cq_strerror(cq, prov_errno, err_data, buf, len);
+}
+
+} // extern "C"

--- a/tests/unit/libfabric_mock_test.cpp
+++ b/tests/unit/libfabric_mock_test.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "libfabric_mock.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::DoAll;
+
+class LibfabricTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		mock = new ::testing::NiceMock<LibfabricMock>();
+		g_libfabric_mock = mock;
+	}
+
+	void TearDown() override {
+		delete mock;
+		g_libfabric_mock = nullptr;
+	}
+
+	LibfabricMock* mock;
+};
+
+TEST_F(LibfabricTest, FiVersionReturnsExpectedValue) {
+	uint32_t expected_version = FI_VERSION(1, 20);
+	
+	EXPECT_CALL(*mock, fi_version())
+		.WillOnce(Return(expected_version));
+	
+	uint32_t version = fi_version();
+	
+	EXPECT_EQ(version, expected_version);
+	EXPECT_EQ(FI_MAJOR(version), 1);
+	EXPECT_EQ(FI_MINOR(version), 20);
+}
+
+TEST_F(LibfabricTest, FiGetinfoWithValidParameters) {
+	struct fi_info* info_ptr = reinterpret_cast<struct fi_info*>(0x1234);
+	struct fi_info hints = {};
+	struct fi_info* result = nullptr;
+	
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(
+			SetArgPointee<5>(info_ptr),
+			Return(0)
+		));
+	
+	int rc = fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, &hints, &result);
+	
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(result, info_ptr);
+}
+
+TEST_F(LibfabricTest, FiStrerrorReturnsErrorString) {
+	const char* error_msg = "Mock error message";
+	
+	EXPECT_CALL(*mock, fi_strerror(-FI_EINVAL))
+		.WillOnce(Return(error_msg));
+	
+	const char* result = fi_strerror(-FI_EINVAL);
+	
+	EXPECT_STREQ(result, error_msg);
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/tests/unit/ofiutils_get_providers_test.cpp
+++ b/tests/unit/ofiutils_get_providers_test.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "libfabric_mock.h"
+
+/*
+ * Provide the logger and param symbols that nccl_ofi_ofiutils.cpp needs.
+ * We define OFI_NCCL_PARAM_DEFINE so the param header stamps out definitions
+ * rather than extern declarations.
+ */
+#include "test-logger.h"
+nccl_ofi_logger_t ofi_log_function = logger;
+
+#define OFI_NCCL_PARAM_DEFINE 1
+#include "nccl_ofi_param.h"
+
+#include "nccl_ofi_ofiutils.h"
+
+#include "nccl_ofi_platform.h"
+
+/*
+ * Stubs for symbols referenced by other functions in
+ * nccl_ofi_ofiutils.cpp that we are not testing here
+ * (e.g., ep_create).  These are never called by the
+ * code paths under test.
+ */
+enum gdr_support_level_t support_gdr = GDR_UNSUPPORTED;
+
+void PlatformManager::register_platform(std::unique_ptr<Platform>&&) {}
+
+PlatformManager& PlatformManager::get_global()
+{
+	static PlatformManager instance;
+	return instance;
+}
+
+uint32_t nccl_ofi_get_unique_node_id() { return 0; }
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::DoAll;
+using ::testing::SetArgPointee;
+using ::testing::Invoke;
+
+/*
+ * Helper to build a minimal fi_info chain for testing.  Allocates real
+ * structs so the filter_provider_list linked-list surgery works on
+ * actual pointers.  Caller must free with free_test_info_list().
+ */
+struct test_fi_info {
+	struct fi_info info;
+	struct fi_fabric_attr fabric_attr;
+	struct fi_domain_attr domain_attr;
+	struct fi_ep_attr ep_attr;
+};
+
+static test_fi_info *alloc_test_info(const char *prov_name,
+				     const char *fabric_name,
+				     const char *domain_name,
+				     uint32_t addr_format = FI_FORMAT_UNSPEC)
+{
+	auto *t = new test_fi_info();
+	memset(t, 0, sizeof(*t));
+
+	t->fabric_attr.prov_name = strdup(prov_name);
+	t->fabric_attr.name = strdup(fabric_name);
+	t->domain_attr.name = strdup(domain_name);
+	t->info.fabric_attr = &t->fabric_attr;
+	t->info.domain_attr = &t->domain_attr;
+	t->info.ep_attr = &t->ep_attr;
+	t->info.addr_format = addr_format;
+
+	return t;
+}
+
+static void free_test_info(test_fi_info *t)
+{
+	free(t->fabric_attr.prov_name);
+	free(t->fabric_attr.name);
+	free(t->domain_attr.name);
+	delete t;
+}
+
+/* Chain a list of test_fi_info into a linked list via ->info.next */
+static struct fi_info *chain_infos(std::vector<test_fi_info *> &infos)
+{
+	for (size_t i = 0; i + 1 < infos.size(); i++)
+		infos[i]->info.next = &infos[i + 1]->info;
+	if (!infos.empty())
+		infos.back()->info.next = nullptr;
+	return &infos[0]->info;
+}
+
+class GetProvidersTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		mock = new ::testing::NiceMock<LibfabricMock>();
+		g_libfabric_mock = mock;
+	}
+
+	void TearDown() override {
+		for (auto *t : test_infos)
+			free_test_info(t);
+		test_infos.clear();
+		delete mock;
+		g_libfabric_mock = nullptr;
+	}
+
+	/*
+	 * Convenience: allocate a test_fi_info, track it for cleanup,
+	 * and return it.
+	 */
+	test_fi_info *make_info(const char *prov, const char *fabric,
+				const char *domain,
+				uint32_t addr_format = FI_FORMAT_UNSPEC)
+	{
+		auto *t = alloc_test_info(prov, fabric, domain, addr_format);
+		test_infos.push_back(t);
+		return t;
+	}
+
+	LibfabricMock *mock;
+	std::vector<test_fi_info *> test_infos;
+};
+
+/*
+ * Verify that nccl_ofi_ofiutils_get_providers() forwards the caller's
+ * arguments to fi_getinfo() exactly: the required_version, NULL node
+ * and service strings, zero flags, and the caller's hints pointer.
+ * Also verify that on failure, *num_prov_infos is zeroed and
+ * *prov_info_list remains NULL.
+ */
+TEST_F(GetProvidersTest, PassesCorrectArgumentsToFiGetinfo) {
+	struct fi_info hints = {};
+	uint32_t version = FI_VERSION(1, 20);
+
+	EXPECT_CALL(*mock, fi_getinfo(version, nullptr, nullptr, 0ULL, &hints, _))
+		.WillOnce(Return(-FI_ENODATA));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 99;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, version, &hints,
+						 &result, &count);
+
+	EXPECT_NE(rc, 0);
+	EXPECT_EQ(result, nullptr);
+	EXPECT_EQ(count, 0u);
+}
+
+/*
+ * Verify that a non-zero error code returned by fi_getinfo() is
+ * propagated unchanged to the caller, and that the output list
+ * pointer remains NULL.
+ */
+TEST_F(GetProvidersTest, PropagatesFiGetinfoFailure) {
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(Return(-FI_ENODATA));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, -FI_ENODATA);
+	EXPECT_EQ(result, nullptr);
+}
+
+/*
+ * Verify that when fi_getinfo() returns success (0) but sets the
+ * output provider list to NULL, get_providers() treats this as
+ * -FI_ENODATA rather than returning success with an empty list.
+ */
+TEST_F(GetProvidersTest, ReturnsErrorWhenGetinfoReturnsNullList) {
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(nullptr), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, -FI_ENODATA);
+}
+
+/*
+ * Verify the happy path: a single EFA provider returned by
+ * fi_getinfo() passes through all filter stages unmodified.
+ * The result list should contain exactly that provider, count
+ * should be 1, and fi_freeinfo() must not be called (no error).
+ */
+TEST_F(GetProvidersTest, SingleEfaProviderNoFilter) {
+	auto *efa = make_info("efa", "efa-fabric", "efa0");
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&efa->info), Return(0)));
+	EXPECT_CALL(*mock, fi_freeinfo(_)).Times(0);
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(result, &efa->info);
+	EXPECT_EQ(count, 1u);
+}
+
+/*
+ * Verify that the prov_include filter correctly removes providers
+ * whose fabric_attr->prov_name does not appear in the include list.
+ *
+ * Setup: fi_getinfo() returns [tcp, efa].  prov_include="efa".
+ * Expected: tcp is removed, only efa remains with count=1.
+ */
+TEST_F(GetProvidersTest, ProvIncludeFiltersToMatchingProvider) {
+	auto *tcp = make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+	make_info("efa", "efa-fabric", "efa0");
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&tcp->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers("efa", FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_STREQ(result->fabric_attr->prov_name, "efa");
+}
+
+/*
+ * Verify that when prov_include filtering removes every provider
+ * from the list, get_providers() returns -FI_ENODATA.
+ *
+ * Also documents a known behavior: fi_freeinfo() is NOT called in
+ * this case because filter_provider_list() sets *providers = NULL
+ * when all entries are removed, and the error path only calls
+ * fi_freeinfo() when providers is non-NULL.  The removed nodes
+ * are effectively leaked by the filter.
+ */
+TEST_F(GetProvidersTest, ProvIncludeFiltersOutAllProviders) {
+	auto *tcp = make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&tcp->info), Return(0)));
+	EXPECT_CALL(*mock, fi_freeinfo(_)).Times(0);
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers("efa", FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, -FI_ENODATA);
+}
+
+/*
+ * Verify that the TCP interface exclusion filter removes TCP
+ * providers whose domain_attr->name appears in the default
+ * OFI_NCCL_EXCLUDE_TCP_IF list ("lo,docker0"), while keeping
+ * TCP providers on other interfaces.
+ *
+ * Setup: fi_getinfo() returns [tcp/lo, tcp/eth0].
+ * Expected: tcp/lo is removed, tcp/eth0 survives.
+ */
+TEST_F(GetProvidersTest, TcpExcludedInterfaceFiltered) {
+	auto *tcp_lo = make_info("tcp", "tcp-fabric", "lo", FI_SOCKADDR_IN);
+	make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&tcp_lo->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_STREQ(result->domain_attr->name, "eth0");
+}
+
+/*
+ * Verify that the TCP interface exclusion filter only applies to
+ * providers whose prov_name starts with "tcp".  A non-TCP provider
+ * (e.g., EFA) with a domain name that matches the exclude list
+ * ("lo") must NOT be filtered out.
+ */
+TEST_F(GetProvidersTest, NonTcpProviderNotAffectedByTcpFilter) {
+	auto *efa = make_info("efa", "efa-fabric", "lo");
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&efa->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_STREQ(result->fabric_attr->prov_name, "efa");
+}
+
+/*
+ * Verify that the TCP address type filter removes TCP providers
+ * with non-IPv4 address formats when OFI_NCCL_USE_IPV6_TCP is
+ * disabled (the default).
+ *
+ * Setup: fi_getinfo() returns [tcp/FI_SOCKADDR_IN6, tcp/FI_SOCKADDR_IN].
+ * Expected: the IPv6 entry is removed, only the IPv4 entry remains.
+ */
+TEST_F(GetProvidersTest, TcpIpv6FilteredWhenDisabled) {
+	auto *tcp_v6 = make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN6);
+	make_info("tcp", "tcp-fabric", "eth1", FI_SOCKADDR_IN);
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&tcp_v6->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_EQ(result->addr_format, (uint32_t)FI_SOCKADDR_IN);
+}
+
+/*
+ * Verify that the match filter (prov_filter_by_match) deduplicates
+ * the provider list to only those entries matching the first
+ * provider's caps, mode, addr_format, endpoint type, protocol,
+ * protocol version, prov_name, and fabric name.
+ *
+ * Setup: fi_getinfo() returns [efa0, efa1, tcp] where both EFA
+ *        entries share identical attributes but TCP differs in
+ *        caps and protocol.
+ * Expected: TCP is removed, both EFA entries remain, count=2.
+ */
+TEST_F(GetProvidersTest, MatchFilterKeepsOnlyMatchingProviders) {
+	auto *efa1 = make_info("efa", "efa-fabric", "efa0");
+	efa1->info.caps = FI_TAGGED | FI_MSG;
+	efa1->ep_attr.type = FI_EP_RDM;
+	efa1->ep_attr.protocol = 1;
+	efa1->ep_attr.protocol_version = 1;
+
+	auto *efa2 = make_info("efa", "efa-fabric", "efa1");
+	efa2->info.caps = FI_TAGGED | FI_MSG;
+	efa2->ep_attr.type = FI_EP_RDM;
+	efa2->ep_attr.protocol = 1;
+	efa2->ep_attr.protocol_version = 1;
+
+	auto *tcp = make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+	tcp->info.caps = FI_MSG;
+	tcp->ep_attr.type = FI_EP_RDM;
+	tcp->ep_attr.protocol = 2;
+	tcp->ep_attr.protocol_version = 1;
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&efa1->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 2u);
+	EXPECT_STREQ(result->fabric_attr->prov_name, "efa");
+	EXPECT_STREQ(result->next->fabric_attr->prov_name, "efa");
+	EXPECT_EQ(result->next->next, nullptr);
+}
+
+/*
+ * Verify that *num_prov_infos correctly counts all providers that
+ * survive filtering.  Three identical EFA providers should all
+ * pass every filter stage and yield count=3.
+ */
+TEST_F(GetProvidersTest, CountsMultipleProviders) {
+	auto *e1 = make_info("efa", "efa-fabric", "efa0");
+	make_info("efa", "efa-fabric", "efa1");
+	make_info("efa", "efa-fabric", "efa2");
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&e1->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 3u);
+}
+
+/*
+ * Verify the error-path cleanup behavior when all providers are
+ * filtered out by the TCP interface exclusion filter.
+ *
+ * A single TCP provider on "docker0" (in the default exclude list)
+ * is removed, leaving providers == NULL.  The error path checks
+ * if (providers) before calling fi_freeinfo(), so fi_freeinfo()
+ * is NOT called.  This documents the current behavior where
+ * filter_provider_list() detaches nodes without freeing them.
+ */
+TEST_F(GetProvidersTest, ErrorPathCallsFreeinfo) {
+	auto *tcp_docker = make_info("tcp", "tcp-fabric", "docker0", FI_SOCKADDR_IN);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&tcp_docker->info), Return(0)));
+
+	EXPECT_CALL(*mock, fi_freeinfo(_)).Times(0);
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_NE(rc, 0);
+}
+
+/*
+ * Verify that prov_include accepts a comma-separated list of
+ * provider names and keeps all matching providers.
+ *
+ * Setup: fi_getinfo() returns [efa, tcp, shm].  prov_include="efa,tcp".
+ * Expected: shm is removed by prov_include.  Then the match filter
+ *           keeps only entries matching the first survivor (efa),
+ *           so tcp is also removed.  Final result: efa only, count=1.
+ */
+TEST_F(GetProvidersTest, ProvIncludeMultipleNames) {
+	auto *efa = make_info("efa", "efa-fabric", "efa0");
+	make_info("tcp", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+	make_info("shm", "shm-fabric", "shm0");
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&efa->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers("efa,tcp", FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_STREQ(result->fabric_attr->prov_name, "efa");
+}
+
+/*
+ * Verify that the TCP interface exclusion filter catches stacked
+ * providers like "tcp;ofi_rxm".  The filter uses strncmp(prov_name,
+ * "tcp", 3) so any provider name starting with "tcp" is subject
+ * to interface exclusion.
+ *
+ * Setup: fi_getinfo() returns [tcp;ofi_rxm/lo, tcp;ofi_rxm/eth0].
+ * Expected: the "lo" entry is removed, "eth0" survives.
+ */
+TEST_F(GetProvidersTest, StackedTcpProviderFiltered) {
+	auto *stacked_lo = make_info("tcp;ofi_rxm", "tcp-fabric", "lo", FI_SOCKADDR_IN);
+	make_info("tcp;ofi_rxm", "tcp-fabric", "eth0", FI_SOCKADDR_IN);
+
+	chain_infos(test_infos);
+
+	EXPECT_CALL(*mock, fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, _, _))
+		.WillOnce(DoAll(SetArgPointee<5>(&stacked_lo->info), Return(0)));
+
+	struct fi_info *result = nullptr;
+	unsigned int count = 0;
+	int rc = nccl_ofi_ofiutils_get_providers(nullptr, FI_VERSION(1, 18),
+						 nullptr, &result, &count);
+
+	EXPECT_EQ(rc, 0);
+	EXPECT_EQ(count, 1u);
+	EXPECT_STREQ(result->domain_attr->name, "eth0");
+}
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Played with Claude to add google-test/google-mock unit testing framework to the plugin.

These changes are very WIP, putting this PR up to present the idea to the team to see if they would be interested in continuing this effort, and making this PR production ready.

```
./tests/unit/ofiutils_get_providers_test
[==========] Running 14 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 14 tests from GetProvidersTest
[ RUN      ] GetProvidersTest.PassesCorrectArgumentsToFiGetinfo
[       OK ] GetProvidersTest.PassesCorrectArgumentsToFiGetinfo (0 ms)
[ RUN      ] GetProvidersTest.PropagatesFiGetinfoFailure
[       OK ] GetProvidersTest.PropagatesFiGetinfoFailure (0 ms)
[ RUN      ] GetProvidersTest.ReturnsErrorWhenGetinfoReturnsNullList
[       OK ] GetProvidersTest.ReturnsErrorWhenGetinfoReturnsNullList (0 ms)
[ RUN      ] GetProvidersTest.SingleEfaProviderNoFilter
[       OK ] GetProvidersTest.SingleEfaProviderNoFilter (0 ms)
[ RUN      ] GetProvidersTest.ProvIncludeFiltersToMatchingProvider
[       OK ] GetProvidersTest.ProvIncludeFiltersToMatchingProvider (0 ms)
[ RUN      ] GetProvidersTest.ProvIncludeFiltersOutAllProviders
[       OK ] GetProvidersTest.ProvIncludeFiltersOutAllProviders (0 ms)
[ RUN      ] GetProvidersTest.TcpExcludedInterfaceFiltered
[       OK ] GetProvidersTest.TcpExcludedInterfaceFiltered (0 ms)
[ RUN      ] GetProvidersTest.NonTcpProviderNotAffectedByTcpFilter
[       OK ] GetProvidersTest.NonTcpProviderNotAffectedByTcpFilter (0 ms)
[ RUN      ] GetProvidersTest.TcpIpv6FilteredWhenDisabled
[       OK ] GetProvidersTest.TcpIpv6FilteredWhenDisabled (0 ms)
[ RUN      ] GetProvidersTest.MatchFilterKeepsOnlyMatchingProviders
[       OK ] GetProvidersTest.MatchFilterKeepsOnlyMatchingProviders (0 ms)
[ RUN      ] GetProvidersTest.CountsMultipleProviders
[       OK ] GetProvidersTest.CountsMultipleProviders (0 ms)
[ RUN      ] GetProvidersTest.ErrorPathCallsFreeinfo
[       OK ] GetProvidersTest.ErrorPathCallsFreeinfo (0 ms)
[ RUN      ] GetProvidersTest.ProvIncludeMultipleNames
[       OK ] GetProvidersTest.ProvIncludeMultipleNames (0 ms)
[ RUN      ] GetProvidersTest.StackedTcpProviderFiltered
[       OK ] GetProvidersTest.StackedTcpProviderFiltered (0 ms)
[----------] 14 tests from GetProvidersTest (0 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 14 tests.
```